### PR TITLE
Moved Markup import from jinja to markupsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This plugin can be installed via:
 
     python -m pip install pelican-podcast
 
+Then add it to your `pelicanconf.py` file:
+
+    PLUGINS = [
+        ...
+        'pelican.plugins.pelican_podcast',
+    ]
+
 Usage
 -----
 

--- a/pelican/plugins/pelican_podcast/pelican_podcast.py
+++ b/pelican/plugins/pelican_podcast/pelican_podcast.py
@@ -7,7 +7,7 @@ import os
 
 from feedgenerator import Rss201rev2Feed
 from feedgenerator.django.utils.feedgenerator import rfc2822_date
-from jinja2 import Markup
+from markupsafe import Markup
 import mutagen
 import six
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 pelican = "^4.5"
+markupsafe = "^2.1.1"
 markdown = {version = "^3.2.2", optional = true}
 mutagen = "^1.45.1"
 


### PR DESCRIPTION
Updated import from jinja2 to markupsafe, which happened in jinja release 3.1.0. Looking for the same version of markupsafe provided by the version of jinja required by pelican. Existing tests pass with `pytest` and `tox` succeeds as well. Added a note to the README about how to install as a plugin.